### PR TITLE
Initial Events API support.

### DIFF
--- a/pkg/eventsapi/v1.go
+++ b/pkg/eventsapi/v1.go
@@ -36,25 +36,20 @@ type ContextV1 struct {
 
 // ResponseV1 corresponds to a V1 response.
 type ResponseV1 struct {
-	Status      string   `json:"status"`
-	Message     string   `json:"message"`
-	IncidentKey string   `json:"incident_key"`
-	Errors      []string `json:"errors"`
+	BaseResponse
 
-	// Not part of the response payload itself, but included for error handling.
-	StatusCode int
+	Status      string   `json:"status,omitempty"`
+	Message     string   `json:"message,omitempty"`
+	IncidentKey string   `json:"incident_key,omitempty"`
+	Errors      []string `json:"errors,omitempty"`
 }
 
 // CreateV1 sends an event to explicitly the Events API V1.
+//
+// Keeping the `create` semantics versus `enqueue` to more closely match the
+// service's own.
 func CreateV1(context context.Context, client *http.Client, event EventV1) (*ResponseV1, error) {
 	response := new(ResponseV1)
-
-	httpResp, err := enqueueEvent(context, client, endpointV1, event, &response)
-	if err != nil {
-		return nil, err
-	}
-
-	response.StatusCode = httpResp.StatusCode
-
-	return response, nil
+	err := enqueueEvent(context, client, endpointV1, event, response)
+	return response, err
 }

--- a/pkg/eventsapi/v1_test.go
+++ b/pkg/eventsapi/v1_test.go
@@ -109,7 +109,7 @@ func TestCreateV1TooManyRequests(t *testing.T) {
 		return
 	}
 
-	if resp.StatusCode != 429 {
+	if resp.HTTPResponse.StatusCode != 429 {
 		t.Errorf("Expected status code to be 429, was %v", resp.Status)
 	}
 }

--- a/pkg/eventsapi/v2.go
+++ b/pkg/eventsapi/v2.go
@@ -44,25 +44,17 @@ type LinkV2 struct {
 
 // ResponseV2 corresponds to a V2 response object.
 type ResponseV2 struct {
+	BaseResponse
+
 	Status   string   `json:"status,omitempty"`
 	Message  string   `json:"message,omitempty"`
 	DedupKey string   `json:"dedupkey,omitempty"`
 	Errors   []string `json:"errors,omitempty"`
-
-	// Not part of the response payload itself, but included for error handling.
-	StatusCode int
 }
 
 // EnqueueV2 sends an event explicitly to the Events API V2.
 func EnqueueV2(context context.Context, client *http.Client, event EventV2) (*ResponseV2, error) {
 	response := new(ResponseV2)
-
-	httpResp, err := enqueueEvent(context, client, endpointV2, event, &response)
-	if err != nil {
-		return nil, err
-	}
-
-	response.StatusCode = httpResp.StatusCode
-
-	return response, nil
+	err := enqueueEvent(context, client, endpointV2, event, response)
+	return response, err
 }

--- a/pkg/eventsapi/v2_test.go
+++ b/pkg/eventsapi/v2_test.go
@@ -121,7 +121,7 @@ func TestEnqueueV2TooManyRequests(t *testing.T) {
 		return
 	}
 
-	if resp.StatusCode != 429 {
+	if resp.HTTPResponse.StatusCode != 429 {
 		t.Errorf("Expected status code to be 429, was %v", resp.Status)
 	}
 }


### PR DESCRIPTION
Decided to add support for both V1 and V2 events, and through a common interface even though they'll come through a single channel for the time being.

For now I'm just treating enums and timestamps as strings, but might do a separate pass to lock them down. We also aren't doing any validation at the moment, but could be something to consider in the future.

Will add tests (including mocking) in a subsequent PR.