### PR TITLE
Fixing build-time variables.

### DIFF
--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -7,7 +7,10 @@ builds:
   env:
   - CGO_ENABLED=0
   ldflags:
-  - -s -w -X common.Version={{.Version}} -X common.Commit={{.ShortCommit}} -X common.Date={{.Date}}
+  - -s -w
+  - -X 'github.com/PagerDuty/pagerduty-agent/pkg/common.Version={{.Version}}'
+  - -X 'github.com/PagerDuty/pagerduty-agent/pkg/common.Commit={{.ShortCommit}}'
+  - -X 'github.com/PagerDuty/pagerduty-agent/pkg/common.Date={{.Date}}'
 archives:
 - replacements:
     darwin: Darwin

--- a/Makefile
+++ b/Makefile
@@ -1,9 +1,14 @@
 build: pdagent
 
 GIT_COMMIT = $(shell git rev-list -1 HEAD)
+BUILD_DATE = $(shell date +%Y-%m-%dT%T%z)
+BUILD_VERSION = $(shell git describe)
 
 pdagent: test
-	go build -o pdagent -ldflags "-s -w -X common.Commit=$(GIT_COMMIT)" .
+	go build -o pdagent -ldflags "-s -w \
+		-X 'github.com/PagerDuty/pagerduty-agent/pkg/common.Commit=$(GIT_COMMIT)' \
+		-X 'github.com/PagerDuty/pagerduty-agent/pkg/common.Date=$(BUILD_DATE)' \
+		-X 'github.com/PagerDuty/pagerduty-agent/pkg/common.Version=$(BUILD_VERSION)'" .
 
 .PHONY: format
 format:

--- a/cmd/version.go
+++ b/cmd/version.go
@@ -1,0 +1,47 @@
+/*
+Copyright © 2020 PagerDuty, Inc. <info@pagerduty.com>
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+package cmd
+
+import (
+	"fmt"
+	"github.com/PagerDuty/pagerduty-agent/pkg/common"
+	"github.com/spf13/cobra"
+)
+
+// versionCmd represents the version command
+var versionCmd = &cobra.Command{
+	Use:   "version",
+	Short: "Version and build information.",
+	Run: func(cmd *cobra.Command, args []string) {
+		fmt.Printf("Version: %v\n", common.Version)
+		fmt.Printf("Build date: %v\n", common.Date)
+		fmt.Printf("Build commit: %v\n", common.Commit)
+	},
+}
+
+func init() {
+	rootCmd.AddCommand(versionCmd)
+
+	// Here you will define your flags and configuration settings.
+
+	// Cobra supports Persistent Flags which will work for this command
+	// and all subcommands, e.g.:
+	// versionCmd.PersistentFlags().String("foo", "", "A help for foo")
+
+	// Cobra supports local flags which will only run when this command
+	// is called directly, e.g.:
+	// versionCmd.Flags().BoolP("toggle", "t", false, "Help message for toggle")
+}

--- a/pkg/common/common.go
+++ b/pkg/common/common.go
@@ -2,25 +2,7 @@ package common
 
 import "time"
 
-// Commit normally auto-injected at build time.
-var Commit = ""
-
-// Date normally auto-injected at build time.
-var Date = ""
-
-// Version normally auto-injected at build time.
-var Version = ""
-
-func init() {
-	if Commit == "" {
-		Commit = "unavailable"
-	}
-
-	if Date == "" {
-		Date = time.Now().Format(time.RFC3339)
-	}
-
-	if Version == "" {
-		Version = "unavailable"
-	}
-}
+// Normally set at build time.
+var Commit = "unavailable"
+var Date = time.Now().Format(time.RFC3339)
+var Version = "unavailable"


### PR DESCRIPTION
First pass didn't account for the need for a proper package path when specifying build-time variables. This pass also attempts to set somewhat-acceptable defaults when building through make.