### PR TITLE
Main routine should call wg add.

### DIFF
--- a/pkg/eventqueue/eventqueue.go
+++ b/pkg/eventqueue/eventqueue.go
@@ -114,12 +114,12 @@ func (q *EventQueue) ensureWorker(key string) {
 	}
 
 	c := make(chan Job, DefaultBufferSize)
+	q.wg.Add(1)
 	go q.worker(key, c)
 	q.queues[key] = c
 }
 
 func (q *EventQueue) worker(key string, c <-chan Job) {
-	q.wg.Add(1)
 	defer q.wg.Done()
 	logger := q.logger.Named(key)
 


### PR DESCRIPTION
Calls `wg.Add` in the conventional location.

> The main goroutine calls Add to set the number of goroutines to wait for. Then each of the goroutines runs and calls Done when finished.

https://golang.org/pkg/sync/#WaitGroup