### PR TITLE
Expand v2 schema support

### DIFF
--- a/README.md
+++ b/README.md
@@ -44,12 +44,12 @@ pdagent help
 Perhaps the most common command, sending events:
 
 ```
-pdagent send \
-  -k v4g5q7yie1qee1yio2uimz8yfbjenvj9 \
+pdagent enqueue \
+  -k your_key_goes_here \
   -t trigger \
-  -d "This is a test event" \
-  -c "PagerDuty Test" \
+  -d "This is only a test" \
   -u "http://pagerduty.com" \
+  -e "error" \
   -f some_field=some_value
 ```
 
@@ -110,10 +110,10 @@ A small helper library used for sending events to both Events API V1 and V2 endp
 
 This project aims to eventually replace the existing `pdagent` project, but with some goals in mind before doing so:
 
-- [x] Events API V1 support
-- [ ] Events API V2 support.
+- [ ] Events API V1 support.
+- [X] Events API V2 support.
     - [X] Parity with existing `pd-send` functionality.
-    - [ ] Comprehensive Events API V2 payload support.
+    - [X] Comprehensive Events API V2 payload support (no links / images yet).
 - [ ] HTTP configuration.
     - [ ] Custom cert files.
     - [x] Proxy and firewall support.

--- a/cmd/enqueue.go
+++ b/cmd/enqueue.go
@@ -1,0 +1,78 @@
+/*
+Copyright © 2020 PagerDuty, Inc. <info@pagerduty.com>
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+package cmd
+
+import (
+	"fmt"
+	"io/ioutil"
+	"os"
+
+	"github.com/PagerDuty/go-pdagent/pkg/client"
+	"github.com/PagerDuty/go-pdagent/pkg/eventsapi"
+	"github.com/spf13/cobra"
+	"github.com/spf13/viper"
+)
+
+var customDetails map[string]string
+
+var sendEvent = eventsapi.EventV2{
+	Payload: eventsapi.PayloadV2{},
+}
+
+func runSendCommand(cmd *cobra.Command, args []string) {
+	c := client.NewClient(viper.GetString("address"), viper.GetString("secret"))
+
+	// Manually mapping as a workaround for the map type mismatch.
+	sendEvent.Payload.CustomDetails = map[string]interface{}{}
+	for k, v := range customDetails {
+		sendEvent.Payload.CustomDetails[k] = v
+	}
+
+	resp, err := c.Send(sendEvent)
+	if err != nil {
+		fmt.Println(err)
+		os.Exit(1)
+	}
+
+	respBody, err := ioutil.ReadAll(resp.Body)
+	if err != nil {
+		fmt.Println(err)
+		os.Exit(1)
+	}
+
+	fmt.Println(string(respBody))
+}
+
+var enqueueCmd = &cobra.Command{
+	Use:   "enqueue",
+	Short: "Queue up a trigger, acknowledge, or resolve v2 event to PagerDuty",
+	Run:   runSendCommand,
+}
+
+func init() {
+	rootCmd.AddCommand(enqueueCmd)
+
+	enqueueCmd.Flags().StringVarP(&sendEvent.RoutingKey, "routing-key", "k", "", "Service Events API Key")
+	enqueueCmd.Flags().StringVarP(&sendEvent.EventAction, "event-action", "t", "", "The type of event")
+	enqueueCmd.Flags().StringVarP(&sendEvent.DedupKey, "dedup-key", "y", "", "Deduplication key for correlating triggers and resolves")
+	enqueueCmd.Flags().StringVarP(&sendEvent.Payload.Summary, "summary", "d", "", "A brief text summary of the event")
+	enqueueCmd.Flags().StringVarP(&sendEvent.Payload.Source, "source", "u", "", "The unique location of the affected system")
+	enqueueCmd.Flags().StringVarP(&sendEvent.Payload.Severity, "severity", "e", "error", "The perceived severity of the status the event is describing with respect to the affected system")
+	enqueueCmd.Flags().StringVar(&sendEvent.Payload.Component, "component", "", "Component of the source machine that is responsible for the event")
+	enqueueCmd.Flags().StringVarP(&sendEvent.Payload.Group, "group", "g", "", "Logical grouping of components of a service")
+	enqueueCmd.Flags().StringVar(&sendEvent.Payload.Class, "class", "", "The class/type of the event")
+	enqueueCmd.Flags().StringToStringVarP(&customDetails, "field", "f", map[string]string{}, "Add given KEY=VALUE pair to the event details")
+}

--- a/cmd/send.go
+++ b/cmd/send.go
@@ -16,62 +16,25 @@ limitations under the License.
 package cmd
 
 import (
-	"fmt"
-	"io/ioutil"
-	"os"
-
-	"github.com/PagerDuty/go-pdagent/pkg/client"
-	"github.com/PagerDuty/go-pdagent/pkg/eventsapi"
 	"github.com/spf13/cobra"
-	"github.com/spf13/viper"
 )
 
-var customDetails map[string]string
-
-var sendEvent = eventsapi.EventV2{
-	Payload: eventsapi.PayloadV2{
-		// TODO Support as CLI option.
-		Severity: "error",
-	},
-}
-
-// sendCmd represents the send command
 var sendCmd = &cobra.Command{
 	Use:   "send",
 	Short: "Queue up a trigger, acknowledge, or resolve event to PagerDuty",
-	Run: func(cmd *cobra.Command, args []string) {
-		c := client.NewClient(viper.GetString("address"), viper.GetString("secret"))
-
-		// Manually mapping as a workaround for the map type mismatch.
-		sendEvent.Payload.CustomDetails = map[string]interface{}{}
-		for k, v := range customDetails {
-			sendEvent.Payload.CustomDetails[k] = v
-		}
-
-		resp, err := c.Send(sendEvent)
-		if err != nil {
-			fmt.Println(err)
-			os.Exit(1)
-		}
-
-		respBody, err := ioutil.ReadAll(resp.Body)
-		if err != nil {
-			fmt.Println(err)
-			os.Exit(1)
-		}
-
-		fmt.Println(string(respBody))
-	},
+	Long: `Queue up a trigger, acknowledge, or resolve V2 event to PagerDuty 
+using a backwards-compatible set of flags.`,
+	Run: runSendCommand,
 }
 
 func init() {
 	rootCmd.AddCommand(sendCmd)
 
-	sendCmd.PersistentFlags().StringVarP(&sendEvent.RoutingKey, "routing-key", "k", "", "Service Events API Key")
-	sendCmd.PersistentFlags().StringVarP(&sendEvent.EventAction, "event-type", "t", "", "Event type")
-	sendCmd.PersistentFlags().StringVarP(&sendEvent.Payload.Summary, "description", "d", "", "Short description of the problem")
-	sendCmd.PersistentFlags().StringVarP(&sendEvent.DedupKey, "incident-key", "i", "", "Incident Key")
-	sendCmd.PersistentFlags().StringVarP(&sendEvent.Payload.Component, "client", "c", "", "Client")
-	sendCmd.PersistentFlags().StringVarP(&sendEvent.Payload.Source, "client-url", "u", "", "Client URL")
-	sendCmd.PersistentFlags().StringToStringVarP(&customDetails, "field", "f", map[string]string{}, "Add given KEY=VALUE pair to the event details")
+	sendCmd.Flags().StringVarP(&sendEvent.RoutingKey, "routing-key", "k", "", "Service Events API Key")
+	sendCmd.Flags().StringVarP(&sendEvent.EventAction, "event-type", "t", "", "Event type")
+	sendCmd.Flags().StringVarP(&sendEvent.Payload.Summary, "description", "d", "", "Short description of the problem")
+	sendCmd.Flags().StringVarP(&sendEvent.DedupKey, "incident-key", "i", "", "Incident Key")
+	sendCmd.Flags().StringVarP(&sendEvent.Payload.Component, "client", "c", "", "Client")
+	sendCmd.Flags().StringVarP(&sendEvent.Payload.Source, "client-url", "u", "", "Client URL")
+	sendCmd.Flags().StringToStringVarP(&customDetails, "field", "f", map[string]string{}, "Add given KEY=VALUE pair to the event details")
 }


### PR DESCRIPTION
Adds a `pdagent enqueue` command with support for V2 event properties except for the `link` and `image` context properties.