### PR TITLE
Make releases with Circle

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -26,7 +26,9 @@ jobs:
             echo $GPG_PASS > ./gpg_pass.txt
       - run:
           name: Cut release
-          command: curl -sL https://git.io/goreleaser | bash -s -- --snapshot --skip-publish --rm-dist
+          command: curl -sL https://git.io/goreleaser | bash -s -- --snapshot --skip-publish
+      - store_artifacts:
+          path: ./dist
   release:
     docker:
       - image: circleci/golang:1.14

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -12,8 +12,50 @@ jobs:
       - git/rebase_on_main
       - run: go mod download
       - run: make
+  release-test:
+    docker:
+      - image: circleci/golang:1.14
+    steps:
+      - checkout
+      - git/rebase_on_main
+      - run:
+          name: Setup GPG signing key
+          command: |
+            echo "$GPG_KEY" | base64 --decode --ignore-garbage | gpg --batch --allow-secret-key-import --import
+            gpg --keyid-format LONG --list-secret-keys
+            echo $GPG_PASS > ./gpg_pass.txt
+      - run:
+          name: Cut release
+          command: curl -sL https://git.io/goreleaser | bash -s -- --snapshot --skip-publish --rm-dist
+  release:
+    docker:
+      - image: circleci/golang:1.14
+    steps:
+      - checkout
+      - git/rebase_on_main
+      - run:
+          name: Setup GPG signing key
+          command: |
+            echo "$GPG_KEY" | base64 --decode --ignore-garbage | gpg --batch --allow-secret-key-import --import
+            gpg --keyid-format LONG --list-secret-keys
+            echo $GPG_PASS > ./gpg_pass.txt
+      - run:
+          name: Cut release
+          command: curl -sL https://git.io/goreleaser | bash
 workflows:
   version: 2
   build_and_test:
     jobs:
       - test
+      - release-test:
+          requires:
+            - test
+      - release:
+          requires:
+            - release-test
+          # Only run this job on git tag pushes
+          filters:
+            branches:
+              only: main
+            tags:
+              only: /v[0-9]+(\.[0-9]+)*(-.*)*/

--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -22,6 +22,8 @@ checksum:
   name_template: 'checksums.txt'
 signs:
 - artifacts: all
+  stdin_file: ./gpg_pass.txt
+  args: ["--batch", "--pinentry-mode=loopback", "--passphrase-fd", "0", "--output", "${signature}", "--detach-sign", "${artifact}"]
 snapshot:
   name_template: "{{ .Tag }}-next"
 changelog:


### PR DESCRIPTION
All commits now run the `test` and `release-test` jobs. The `release` job is only run on `main` and when tagged.

This is an adaptation of the barebones implementation found on the `goreleaser` website: https://goreleaser.com/ci/circle/