### PR TITLE
Fixes workflow filter.

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -56,6 +56,6 @@ workflows:
             - release-test
           filters:
             branches:
-              only: main
+              ignore: /.*/
             tags:
               only: /v[0-9]+(\.[0-9]+)*(-.*)*/


### PR DESCRIPTION
Workflow filters act as an "or".  Here we never trigger the release job on a branch commit.  Only on a tag...