### PR TITLE
Goreleaser config no longer uses deprecated files field

### DIFF
--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -49,10 +49,13 @@ nfpms:
     - /var/lib/pdagent
     - /var/log/pdagent
     - /var/run/pdagent
-  files:
-    "init/pdagent.init": "/var/lib/pdagent/scripts/pdagent.init"
-    "init/pdagent.service": "/var/lib/pdagent/scripts/pdagent.service"
-    "scripts/pd-*": "/usr/local/bin/"
+  contents:
+    - src: "init/pdagent.init"
+      dst: "/var/lib/pdagent/scripts/pdagent.init"
+    - src: "init/pdagent.service"
+      dst: "/var/lib/pdagent/scripts/pdagent.service"
+    - src: "scripts/pd-*"
+      dst: "/usr/local/bin/"
   overrides:
     deb:
       scripts:


### PR DESCRIPTION
nFPM doesn't support `files` fields. It is now supported via `contents` field. 

Example of nFPM code change showing this deprecation:
https://github.com/goreleaser/nfpm/pull/267/files#diff-431e740212793ac89fe457788a44a678bdade8977edd5b527233de287f89669eL20-R27