### PR TITLE
Adds EU support

### DIFF
--- a/cmd/integrations/nagios/nagios_enqueue.go
+++ b/cmd/integrations/nagios/nagios_enqueue.go
@@ -134,11 +134,11 @@ func buildDedupKey(cmdInputs nagiosEnqueueInput) string {
 }
 
 func validateNagiosSendCommand(cmdInputs nagiosEnqueueInput) error {
-	if err := validateEnumField(cmdInputs.notificationType, allowedNotificationTypes, errNotificationType); err != nil {
+	if err := cmdutil.ValidateEnumField(cmdInputs.notificationType, allowedNotificationTypes, errNotificationType); err != nil {
 		return err
 	}
 
-	if err := validateEnumField(cmdInputs.sourceType, allowedSourceTypes, errSourceType); err != nil {
+	if err := cmdutil.ValidateEnumField(cmdInputs.sourceType, allowedSourceTypes, errSourceType); err != nil {
 		return err
 	}
 
@@ -147,15 +147,6 @@ func validateNagiosSendCommand(cmdInputs nagiosEnqueueInput) error {
 	}
 
 	return nil
-}
-
-func validateEnumField(inputVal string, allowedValues []string, err error) error {
-	for _, value := range allowedValues {
-		if value == inputVal {
-			return nil
-		}
-	}
-	return err
 }
 
 func validateCustomDetails(cmdInputs nagiosEnqueueInput) error {

--- a/cmd/server.go
+++ b/cmd/server.go
@@ -43,7 +43,7 @@ func NewServerCmd() *cobra.Command {
 	defaults := cmdutil.GetDefaults()
 
 	cmd.PersistentFlags().String("database", defaults.Database, "database file for event queuing (default is /var/db/pdagent/agent.db)")
-	cmd.PersistentFlags().String("region", defaults.Region, `PagerDuty region the daemon sends events to, either "us" or  "eu"`)
+	cmd.PersistentFlags().String("region", defaults.Region, `PagerDuty region the daemon sends events to, either "us" or "eu"`)
 
 	if err := viper.BindPFlag("database", cmd.PersistentFlags().Lookup("database")); err != nil {
 		fmt.Println(err)

--- a/cmd/server.go
+++ b/cmd/server.go
@@ -43,7 +43,7 @@ func NewServerCmd() *cobra.Command {
 	defaults := cmdutil.GetDefaults()
 
 	cmd.PersistentFlags().String("database", defaults.Database, "database file for event queuing (default is /var/db/pdagent/agent.db)")
-	cmd.PersistentFlags().String("region", defaults.Region, `PagerDuty region the daemon sends events to, either "us" (default) or  "eu"`)
+	cmd.PersistentFlags().String("region", defaults.Region, `PagerDuty region the daemon sends events to, either "us" or  "eu"`)
 
 	if err := viper.BindPFlag("database", cmd.PersistentFlags().Lookup("database")); err != nil {
 		fmt.Println(err)

--- a/cmd/server.go
+++ b/cmd/server.go
@@ -42,7 +42,7 @@ func NewServerCmd() *cobra.Command {
 
 	defaults := cmdutil.GetDefaults()
 
-	cmd.PersistentFlags().String("database", defaults.Database, "database file for event queuing (default is /var/db/pdagent/agent.db)")
+	cmd.PersistentFlags().String("database", defaults.Database, "database file for event queuing")
 	cmd.PersistentFlags().String("region", defaults.Region, `PagerDuty region the daemon sends events to, either "us" or "eu"`)
 
 	if err := viper.BindPFlag("database", cmd.PersistentFlags().Lookup("database")); err != nil {

--- a/pkg/cmdutil/defaults.go
+++ b/pkg/cmdutil/defaults.go
@@ -30,6 +30,7 @@ type Defaults struct {
 	Database   string
 	Pidfile    string
 	Secret     string
+	Region     string
 }
 
 func GetDefaults() Defaults {
@@ -42,6 +43,7 @@ func GetDefaults() Defaults {
 			Database:   "/var/db/pdagent/pdagent.db",
 			Pidfile:    "/var/run/pdagent/pidfile",
 			Secret:     common.GenerateKey(),
+			Region:     "us",
 		}
 	}
 
@@ -53,6 +55,7 @@ func GetDefaults() Defaults {
 		Database:   path.Join(configPath, "pdagent.db"),
 		Pidfile:    path.Join(configPath, "pidfile"),
 		Secret:     common.GenerateKey(),
+		Region:     "us",
 	}
 }
 

--- a/pkg/cmdutil/validate.go
+++ b/pkg/cmdutil/validate.go
@@ -1,0 +1,10 @@
+package cmdutil
+
+func ValidateEnumField(inputVal string, allowedValues []string, err error) error {
+	for _, value := range allowedValues {
+		if value == inputVal {
+			return nil
+		}
+	}
+	return err
+}

--- a/pkg/common/common.go
+++ b/pkg/common/common.go
@@ -5,6 +5,8 @@ import (
 	"os"
 	"runtime"
 	"time"
+
+	"github.com/spf13/viper"
 )
 
 // Normally set at build time.
@@ -37,4 +39,20 @@ func UserAgent() string {
 	date := Date
 
 	return fmt.Sprintf("go-pdagent/%v (%v, commit: %v, date: %v)", version, system, commit, date)
+}
+
+func PdEventsUrl() string {
+	region := viper.GetString("region")
+	if region == "eu" {
+		return "https://events.eu.pagerduty.com"
+	}
+	return "https://events.pagerduty.com"
+}
+
+func PdApiUrl() string {
+	region := viper.GetString("region")
+	if region == "eu" {
+		return "https://api.eu.pagerduty.com"
+	}
+	return "https://api.pagerduty.com"
 }

--- a/pkg/eventsapi/v1.go
+++ b/pkg/eventsapi/v1.go
@@ -2,13 +2,12 @@ package eventsapi
 
 import (
 	"context"
-	"fmt"
 	"net/http"
 
 	"github.com/PagerDuty/go-pdagent/pkg/common"
 )
 
-var endpointV1 = fmt.Sprintf("%v/generic/2010-04-15/create_event.json", common.PdEventsUrl())
+const endpointV1 = "/generic/2010-04-15/create_event.json"
 
 // EventV1 corresponds to a V1 event object.
 type EventV1 struct {
@@ -76,6 +75,7 @@ type ResponseV1 struct {
 // service's own.
 func CreateV1(context context.Context, client *http.Client, event *EventV1) (*ResponseV1, error) {
 	var response ResponseV1
-	err := enqueueEvent(context, client, endpointV1, event, &response)
+	requestUrl := common.PdEventsUrl() + endpointV1
+	err := enqueueEvent(context, client, requestUrl, event, &response)
 	return &response, err
 }

--- a/pkg/eventsapi/v1.go
+++ b/pkg/eventsapi/v1.go
@@ -2,10 +2,13 @@ package eventsapi
 
 import (
 	"context"
+	"fmt"
 	"net/http"
+
+	"github.com/PagerDuty/go-pdagent/pkg/common"
 )
 
-const endpointV1 = "https://events.pagerduty.com/generic/2010-04-15/create_event.json"
+var endpointV1 = fmt.Sprintf("%v/generic/2010-04-15/create_event.json", common.PdEventsUrl())
 
 // EventV1 corresponds to a V1 event object.
 type EventV1 struct {

--- a/pkg/eventsapi/v1.go
+++ b/pkg/eventsapi/v1.go
@@ -75,7 +75,7 @@ type ResponseV1 struct {
 // service's own.
 func CreateV1(context context.Context, client *http.Client, event *EventV1) (*ResponseV1, error) {
 	var response ResponseV1
-	requestUrl := common.PdEventsUrl() + endpointV1
-	err := enqueueEvent(context, client, requestUrl, event, &response)
+	url := common.PdEventsUrl() + endpointV1
+	err := enqueueEvent(context, client, url, event, &response)
 	return &response, err
 }

--- a/pkg/eventsapi/v2.go
+++ b/pkg/eventsapi/v2.go
@@ -7,7 +7,7 @@ import (
 	"github.com/PagerDuty/go-pdagent/pkg/common"
 )
 
-var endpointV2 = "/v2/enqueue"
+const endpointV2 = "/v2/enqueue"
 
 // EventV2 corresponds to a V2 event object.
 type EventV2 struct {

--- a/pkg/eventsapi/v2.go
+++ b/pkg/eventsapi/v2.go
@@ -80,7 +80,7 @@ type ResponseV2 struct {
 // EnqueueV2 sends an event explicitly to the Events API V2.
 func EnqueueV2(context context.Context, client *http.Client, event *EventV2) (*ResponseV2, error) {
 	var response ResponseV2
-	requestUrl := common.PdEventsUrl() + endpointV2
-	err := enqueueEvent(context, client, requestUrl, event, &response)
+	url := common.PdEventsUrl() + endpointV2
+	err := enqueueEvent(context, client, url, event, &response)
 	return &response, err
 }

--- a/pkg/eventsapi/v2.go
+++ b/pkg/eventsapi/v2.go
@@ -2,13 +2,12 @@ package eventsapi
 
 import (
 	"context"
-	"fmt"
 	"net/http"
 
 	"github.com/PagerDuty/go-pdagent/pkg/common"
 )
 
-var endpointV2 = fmt.Sprintf("%v/v2/enqueue", common.PdEventsUrl())
+var endpointV2 = "/v2/enqueue"
 
 // EventV2 corresponds to a V2 event object.
 type EventV2 struct {
@@ -81,6 +80,7 @@ type ResponseV2 struct {
 // EnqueueV2 sends an event explicitly to the Events API V2.
 func EnqueueV2(context context.Context, client *http.Client, event *EventV2) (*ResponseV2, error) {
 	var response ResponseV2
-	err := enqueueEvent(context, client, endpointV2, event, &response)
+	requestUrl := common.PdEventsUrl() + endpointV2
+	err := enqueueEvent(context, client, requestUrl, event, &response)
 	return &response, err
 }

--- a/pkg/eventsapi/v2.go
+++ b/pkg/eventsapi/v2.go
@@ -2,10 +2,13 @@ package eventsapi
 
 import (
 	"context"
+	"fmt"
 	"net/http"
+
+	"github.com/PagerDuty/go-pdagent/pkg/common"
 )
 
-const endpointV2 = "https://events.pagerduty.com/v2/enqueue"
+var endpointV2 = fmt.Sprintf("%v/v2/enqueue", common.PdEventsUrl())
 
 // EventV2 corresponds to a V2 event object.
 type EventV2 struct {

--- a/pkg/server/heartbeat.go
+++ b/pkg/server/heartbeat.go
@@ -93,8 +93,8 @@ func (hb *heartbeat) beat() {
 }
 
 func (hb *heartbeat) doHeartbeatRequest() (*heartbeatResponseBody, error) {
-	heartbeatUrl := common.PdApiUrl() + endpoint
-	req, err := http.NewRequest("GET", heartbeatUrl, nil)
+	url := common.PdApiUrl() + endpoint
+	req, err := http.NewRequest("GET", url, nil)
 	if err != nil {
 		return nil, err
 	}

--- a/pkg/server/heartbeat.go
+++ b/pkg/server/heartbeat.go
@@ -3,6 +3,7 @@ package server
 import (
 	"encoding/json"
 	"errors"
+	"fmt"
 	"io/ioutil"
 	"net/http"
 	"time"
@@ -11,11 +12,11 @@ import (
 	"go.uber.org/zap"
 )
 
-const url = "https://api.pagerduty.com/agent/2014-03-14/heartbeat/go-pdagent"
 const frequencySeconds = 60 * 60 // Send heartbeat every hour
 const maxRetries = 3
 const maxRetryInterval = 15 * time.Second
 
+var url = fmt.Sprintf("%v/agent/2014-03-14/heartbeat/go-pdagent", common.PdApiUrl())
 var ErrHeartbeatError = errors.New("an error was encountered while sending the heartbeat")
 
 type Heartbeat interface {

--- a/pkg/server/heartbeat.go
+++ b/pkg/server/heartbeat.go
@@ -11,10 +11,10 @@ import (
 	"go.uber.org/zap"
 )
 
+const endpoint = "/agent/2014-03-14/heartbeat/go-pdagent"
 const frequencySeconds = 60 * 60 // Send heartbeat every hour
 const maxRetries = 3
 const maxRetryInterval = 15 * time.Second
-const heartbeatEndpoint = "/agent/2014-03-14/heartbeat/go-pdagent"
 
 var ErrHeartbeatError = errors.New("an error was encountered while sending the heartbeat")
 
@@ -93,7 +93,7 @@ func (hb *heartbeat) beat() {
 }
 
 func (hb *heartbeat) doHeartbeatRequest() (*heartbeatResponseBody, error) {
-	heartbeatUrl := common.PdApiUrl() + heartbeatEndpoint
+	heartbeatUrl := common.PdApiUrl() + endpoint
 	req, err := http.NewRequest("GET", heartbeatUrl, nil)
 	if err != nil {
 		return nil, err

--- a/pkg/server/heartbeat.go
+++ b/pkg/server/heartbeat.go
@@ -3,7 +3,6 @@ package server
 import (
 	"encoding/json"
 	"errors"
-	"fmt"
 	"io/ioutil"
 	"net/http"
 	"time"
@@ -15,8 +14,8 @@ import (
 const frequencySeconds = 60 * 60 // Send heartbeat every hour
 const maxRetries = 3
 const maxRetryInterval = 15 * time.Second
+const heartbeatEndpoint = "/agent/2014-03-14/heartbeat/go-pdagent"
 
-var url = fmt.Sprintf("%v/agent/2014-03-14/heartbeat/go-pdagent", common.PdApiUrl())
 var ErrHeartbeatError = errors.New("an error was encountered while sending the heartbeat")
 
 type Heartbeat interface {
@@ -94,7 +93,8 @@ func (hb *heartbeat) beat() {
 }
 
 func (hb *heartbeat) doHeartbeatRequest() (*heartbeatResponseBody, error) {
-	req, err := http.NewRequest("GET", url, nil)
+	heartbeatUrl := common.PdApiUrl() + heartbeatEndpoint
+	req, err := http.NewRequest("GET", heartbeatUrl, nil)
 	if err != nil {
 		return nil, err
 	}


### PR DESCRIPTION
Adds a `region` flag to the `server` command that can be either `us` or `eu` and determines which PagerDuty region the daemon should talk to. If the flag is not provided it defaults to `us`. 