### PR TITLE
Send agent context in integration request bodies

### DIFF
--- a/cmd/integrations/nagios/nagios_enqueue.go
+++ b/cmd/integrations/nagios/nagios_enqueue.go
@@ -34,7 +34,7 @@ type nagiosEnqueueInput struct {
 	customFields     map[string]string
 }
 
-var clock common.Clock = common.RealClock{}
+var clock common.Clock = common.NewClock()
 
 var allowedNotificationTypes = []string{"PROBLEM", "ACKNOWLEDGEMENT", "RECOVERY"}
 var allowedSourceTypes = []string{"host", "service"}

--- a/cmd/integrations/nagios/nagios_enqueue_test.go
+++ b/cmd/integrations/nagios/nagios_enqueue_test.go
@@ -23,6 +23,7 @@ import (
 	"time"
 
 	"github.com/PagerDuty/go-pdagent/pkg/cmdutil"
+	"github.com/PagerDuty/go-pdagent/pkg/common"
 	"github.com/PagerDuty/go-pdagent/test"
 	"github.com/stretchr/testify/assert"
 	"gopkg.in/h2non/gock.v1"
@@ -198,6 +199,7 @@ func TestNagiosEnqueue_validInputs(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
+			clock = test.TestClock{}
 			test.InitConfigForIntegrationsTesting()
 
 			defer gock.Off()
@@ -232,6 +234,11 @@ func TestNagiosEnqueue_validInputs(t *testing.T) {
 				"incident_key": incidentKey,
 				"description":  buildEventDescription(tt.cmdInputs),
 				"details":      customDetails,
+				"agent": map[string]interface{}{
+					"agent_id":  common.UserAgent(),
+					"queued_by": "pd-nagios",
+					"queued_at": "2021-01-01T00:00:00Z",
+				},
 			}
 
 			gock.New(cmdutil.GetDefaults().Address).

--- a/cmd/integrations/sensu/sensu_enqueue.go
+++ b/cmd/integrations/sensu/sensu_enqueue.go
@@ -20,7 +20,7 @@ type sensuCommandInput struct {
 	checkResult    map[string]interface{}
 }
 
-var clock common.Clock = common.RealClock{}
+var clock common.Clock = common.NewClock()
 
 var errCouldNotReadStdin = errors.New(`could not read stdin for sensu enqueue command`)
 var errCheckResultNotValidJson = errors.New("could not unmarshal check result, perhaps stdin did not contain valid JSON")

--- a/cmd/integrations/sensu/sensu_enqueue_test.go
+++ b/cmd/integrations/sensu/sensu_enqueue_test.go
@@ -27,6 +27,7 @@ import (
 	"time"
 
 	"github.com/PagerDuty/go-pdagent/pkg/cmdutil"
+	"github.com/PagerDuty/go-pdagent/pkg/common"
 	"github.com/PagerDuty/go-pdagent/test"
 	"github.com/stretchr/testify/assert"
 	"gopkg.in/h2non/gock.v1"
@@ -229,6 +230,12 @@ func TestSensuEnqueue_validInputs(t *testing.T) {
 					},
 					"client": map[string]interface{}{"name": "clientname"},
 				},
+				"agent": map[string]interface{}{
+					"agent_id":  common.UserAgent(),
+					"queued_by": "pd-sensu",
+					"queued_at": "2021-01-01T00:00:00Z",
+				},
+				"client": "Sensu",
 			},
 		},
 		{
@@ -251,6 +258,12 @@ func TestSensuEnqueue_validInputs(t *testing.T) {
 					"check":  map[string]interface{}{"output": "output"},
 					"id":     "some_id",
 				},
+				"agent": map[string]interface{}{
+					"agent_id":  common.UserAgent(),
+					"queued_by": "pd-sensu",
+					"queued_at": "2021-01-01T00:00:00Z",
+				},
+				"client": "Sensu",
 			},
 		},
 		{
@@ -272,6 +285,12 @@ func TestSensuEnqueue_validInputs(t *testing.T) {
 					"action": "action",
 					"check":  map[string]interface{}{"output": "output"},
 				},
+				"agent": map[string]interface{}{
+					"agent_id":  common.UserAgent(),
+					"queued_by": "pd-sensu",
+					"queued_at": "2021-01-01T00:00:00Z",
+				},
+				"client": "Sensu",
 			},
 		},
 		{
@@ -293,6 +312,12 @@ func TestSensuEnqueue_validInputs(t *testing.T) {
 					"action": "create",
 					"check":  map[string]interface{}{"output": "output"},
 				},
+				"agent": map[string]interface{}{
+					"agent_id":  common.UserAgent(),
+					"queued_by": "pd-sensu",
+					"queued_at": "2021-01-01T00:00:00Z",
+				},
+				"client": "Sensu",
 			},
 		},
 		{
@@ -314,11 +339,18 @@ func TestSensuEnqueue_validInputs(t *testing.T) {
 					"action": "resolve",
 					"check":  map[string]interface{}{"output": "output"},
 				},
+				"agent": map[string]interface{}{
+					"agent_id":  common.UserAgent(),
+					"queued_by": "pd-sensu",
+					"queued_at": "2021-01-01T00:00:00Z",
+				},
+				"client": "Sensu",
 			},
 		},
 	}
 
 	for _, tt := range tests {
+		clock = test.TestClock{}
 		t.Run(tt.name, func(t *testing.T) {
 			test.InitConfigForIntegrationsTesting()
 

--- a/cmd/integrations/zabbix/zabbix_enqueue.go
+++ b/cmd/integrations/zabbix/zabbix_enqueue.go
@@ -18,7 +18,7 @@ type zabbixCommandInput struct {
 	details        map[string]string
 }
 
-var clock common.Clock = common.RealClock{}
+var clock common.Clock = common.NewClock()
 
 var errCouldNotBuildDedupKey = errors.New(`could not build dedupKey, ensure event contains "incident_key", or "id" and "hostname"`)
 var errCouldNotBuildSummary = errors.New(`could not build summary, ensure event contains "name", "status", and "hostname"`)

--- a/cmd/integrations/zabbix/zabbix_enqueue.go
+++ b/cmd/integrations/zabbix/zabbix_enqueue.go
@@ -4,8 +4,10 @@ import (
 	"errors"
 	"fmt"
 	"strings"
+	"time"
 
 	"github.com/PagerDuty/go-pdagent/pkg/cmdutil"
+	"github.com/PagerDuty/go-pdagent/pkg/common"
 	"github.com/PagerDuty/go-pdagent/pkg/eventsapi"
 	"github.com/spf13/cobra"
 )
@@ -15,6 +17,8 @@ type zabbixCommandInput struct {
 	messageType    string
 	details        map[string]string
 }
+
+var clock common.Clock = common.RealClock{}
 
 var errCouldNotBuildDedupKey = errors.New(`could not build dedupKey, ensure event contains "incident_key", or "id" and "hostname"`)
 var errCouldNotBuildSummary = errors.New(`could not build summary, ensure event contains "name", "status", and "hostname"`)
@@ -59,6 +63,11 @@ func buildSendEvent(cmdInput zabbixCommandInput) (eventsapi.EventV1, error) {
 		ClientURL:   clientUrl,
 		Description: summary,
 		Details:     cmdutil.StringMapToInterfaceMap(cmdInput.details),
+		Agent: eventsapi.AgentContext{
+			QueuedBy: "pd-zabbix",
+			QueuedAt: clock.Now().UTC().Format(time.RFC3339),
+			AgentId:  common.UserAgent(),
+		},
 	}
 
 	return sendEvent, nil

--- a/cmd/integrations/zabbix/zabbix_enqueue_test.go
+++ b/cmd/integrations/zabbix/zabbix_enqueue_test.go
@@ -23,6 +23,7 @@ import (
 	"time"
 
 	"github.com/PagerDuty/go-pdagent/pkg/cmdutil"
+	"github.com/PagerDuty/go-pdagent/pkg/common"
 	"github.com/PagerDuty/go-pdagent/test"
 	"github.com/stretchr/testify/assert"
 	"gopkg.in/h2non/gock.v1"
@@ -134,6 +135,11 @@ func TestZabbixEnqueue_validInputs(t *testing.T) {
 					"status":   "{TRIGGER.STATUS}",
 					"hostname": "{HOST.NAME}",
 				},
+				"agent": map[string]interface{}{
+					"agent_id":  common.UserAgent(),
+					"queued_by": "pd-zabbix",
+					"queued_at": "2021-01-01T00:00:00Z",
+				},
 			},
 		},
 		{
@@ -156,6 +162,11 @@ func TestZabbixEnqueue_validInputs(t *testing.T) {
 					"incident_key": "provided_incident_key",
 					"status":       "{TRIGGER.STATUS}",
 					"hostname":     "{HOST.NAME}",
+				},
+				"agent": map[string]interface{}{
+					"agent_id":  common.UserAgent(),
+					"queued_by": "pd-zabbix",
+					"queued_at": "2021-01-01T00:00:00Z",
 				},
 			},
 		},
@@ -181,6 +192,11 @@ func TestZabbixEnqueue_validInputs(t *testing.T) {
 					"status":   "{TRIGGER.STATUS}",
 					"hostname": "{HOST.NAME}",
 					"NOTE":     "Escalation cancelled (converted from trigger to resolve by pdagent integration)",
+				},
+				"agent": map[string]interface{}{
+					"agent_id":  common.UserAgent(),
+					"queued_by": "pd-zabbix",
+					"queued_at": "2021-01-01T00:00:00Z",
 				},
 			},
 		},
@@ -209,6 +225,11 @@ func TestZabbixEnqueue_validInputs(t *testing.T) {
 					"hostname": "{HOST.NAME}",
 					"url":      "some.url",
 				},
+				"agent": map[string]interface{}{
+					"agent_id":  common.UserAgent(),
+					"queued_by": "pd-zabbix",
+					"queued_at": "2021-01-01T00:00:00Z",
+				},
 			},
 		},
 		{
@@ -235,12 +256,18 @@ func TestZabbixEnqueue_validInputs(t *testing.T) {
 					"hostname":          "{HOST.NAME}",
 					"someErrantKeyHere": "someErrantKeyHere",
 				},
+				"agent": map[string]interface{}{
+					"agent_id":  common.UserAgent(),
+					"queued_by": "pd-zabbix",
+					"queued_at": "2021-01-01T00:00:00Z",
+				},
 			},
 		},
 	}
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
+			clock = test.TestClock{}
 			test.InitConfigForIntegrationsTesting()
 
 			defer gock.Off()

--- a/pkg/common/clock.go
+++ b/pkg/common/clock.go
@@ -1,0 +1,11 @@
+package common
+
+import "time"
+
+type Clock interface {
+	Now() time.Time
+}
+
+type RealClock struct{}
+
+func (RealClock) Now() time.Time { return time.Now() }

--- a/pkg/common/clock.go
+++ b/pkg/common/clock.go
@@ -6,6 +6,11 @@ type Clock interface {
 	Now() time.Time
 }
 
-type RealClock struct{}
+type realClock struct{}
 
-func (RealClock) Now() time.Time { return time.Now() }
+func NewClock() Clock {
+	c := &realClock{}
+	return c
+}
+
+func (realClock) Now() time.Time { return time.Now() }

--- a/pkg/eventsapi/v1.go
+++ b/pkg/eventsapi/v1.go
@@ -11,14 +11,15 @@ const endpointV1 = "/generic/2010-04-15/create_event.json"
 
 // EventV1 corresponds to a V1 event object.
 type EventV1 struct {
-	ServiceKey  string      `json:"service_key"`
-	EventType   string      `json:"event_type"`
-	IncidentKey string      `json:"incident_key,omitempty"`
-	Description string      `json:"description"`
-	Details     DetailsV1   `json:"details,omitempty"`
-	Client      string      `json:"client,omitempty"`
-	ClientURL   string      `json:"client_url,omitempty"`
-	Contexts    []ContextV1 `json:"contexts,omitempty"`
+	ServiceKey  string       `json:"service_key"`
+	EventType   string       `json:"event_type"`
+	IncidentKey string       `json:"incident_key,omitempty"`
+	Description string       `json:"description"`
+	Details     DetailsV1    `json:"details,omitempty"`
+	Client      string       `json:"client,omitempty"`
+	ClientURL   string       `json:"client_url,omitempty"`
+	Contexts    []ContextV1  `json:"contexts,omitempty"`
+	Agent       AgentContext `json:"agent,omitempty"`
 }
 
 func (e *EventV1) GetRoutingKey() string {
@@ -39,6 +40,13 @@ func (e *EventV1) Version() EventVersion {
 
 // DetailsV1 corresponds to a V1 details object.
 type DetailsV1 map[string]interface{}
+
+// AgentContext is used for pdagent integrations
+type AgentContext struct {
+	QueuedBy string `json:"queued_by"`
+	QueuedAt string `json:"queued_at"`
+	AgentId  string `json:"agent_id"`
+}
 
 // ContextV1 corresponds to a V1 context object.
 //

--- a/test/clock.go
+++ b/test/clock.go
@@ -1,0 +1,7 @@
+package test
+
+import "time"
+
+type TestClock struct{}
+
+func (TestClock) Now() time.Time { return time.Date(2021, time.January, 1, 0, 0, 0, 0, time.UTC) }

--- a/test/helpers.go
+++ b/test/helpers.go
@@ -20,7 +20,6 @@ import (
 	"encoding/json"
 	"io"
 	"os"
-	"time"
 
 	"github.com/PagerDuty/go-pdagent/pkg/cmdutil"
 	"github.com/PagerDuty/go-pdagent/pkg/eventsapi"
@@ -73,7 +72,3 @@ func BuildV2EventContainer(key string) eventsapi.EventContainer {
 		EventData:    jsonEvent,
 	}
 }
-
-type TestClock struct{}
-
-func (TestClock) Now() time.Time { return time.Date(2021, time.January, 1, 0, 0, 0, 0, time.UTC) }

--- a/test/helpers.go
+++ b/test/helpers.go
@@ -20,6 +20,7 @@ import (
 	"encoding/json"
 	"io"
 	"os"
+	"time"
 
 	"github.com/PagerDuty/go-pdagent/pkg/cmdutil"
 	"github.com/PagerDuty/go-pdagent/pkg/eventsapi"
@@ -72,3 +73,7 @@ func BuildV2EventContainer(key string) eventsapi.EventContainer {
 		EventData:    jsonEvent,
 	}
 }
+
+type TestClock struct{}
+
+func (TestClock) Now() time.Time { return time.Date(2021, time.January, 1, 0, 0, 0, 0, time.UTC) }


### PR DESCRIPTION
Add agent context to integration request bodies so that all integrations can work with a Global Event Routing Key.