### PR TITLE
CLI Health Check Command

### DIFF
--- a/README.md
+++ b/README.md
@@ -58,36 +58,3 @@ At a high level, the agent has three key components:
 ## Development
 
 Looking to contribute? See [development](/docs/development.md) for some helpful tips.
-
-## Current Status
-
-This project aims to eventually replace the existing `pdagent` project, but with some goals in mind before doing so:
-
-- [x] Events API V1 support.
-- [X] Events API V2 support.
-    - [X] Parity with existing `pd-send` functionality.
-    - [X] Comprehensive Events API V2 payload support (no links / images yet).
-- [ ] HTTP configuration.
-    - [ ] Custom cert files.
-    - [x] Proxy and firewall support.
-    - [ ] Local server security.
-- [X] Event queuing.
-- [X] Persistent queuing.
-- [x] Legacy command wrappers.
-    - [x] `pd-send`
-    - [x] `pd-queue`
-- [ ] Releasing
-    - [x] Init and pre/post install scripts.
-    - [X] Github release support.
-        - [X] Source
-        - [X] Darwin
-        - [X] Linux (deb/rpm)
-        - [X] Checksums.
-        - [X] Signature files.
-    - [ ] `deb` repo support.
-    - [ ] `rpm` repo support.
-        - [ ] Signed packages.
-- [ ] `pdagent-integrations` support.
-    - [x] `pd-nagios`
-    - [x] `pd-sensu`
-    - [x] `pd-zabbix`

--- a/cmd/health.go
+++ b/cmd/health.go
@@ -1,0 +1,56 @@
+/*
+Copyright © 2020 PagerDuty, Inc. <info@pagerduty.com>
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+package cmd
+
+import (
+	"fmt"
+	"io/ioutil"
+	"os"
+
+	"github.com/PagerDuty/go-pdagent/pkg/cmdutil"
+	"github.com/spf13/cobra"
+)
+
+func NewHealthCmd(config *cmdutil.Config) *cobra.Command {
+	cmd := &cobra.Command{
+		Use:   "health",
+		Short: "Check the health of the server.",
+		RunE: func(cmd *cobra.Command, args []string) error {
+			return runHealthCommand(config)
+		},
+	}
+
+	return cmd
+}
+
+func runHealthCommand(config *cmdutil.Config) error {
+	c, _ := config.Client()
+
+	resp, err := c.HealthCheck()
+	if err != nil {
+		fmt.Println(err)
+		os.Exit(1)
+	}
+
+	respBody, err := ioutil.ReadAll(resp.Body)
+	if err != nil {
+		fmt.Println(err)
+		os.Exit(1)
+	}
+
+	fmt.Println(string(respBody))
+	return nil
+}

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -86,6 +86,7 @@ func NewRootCmd(config *cmdutil.Config) *cobra.Command {
 
 	// All top-level commands go here
 	rootCmd.AddCommand(NewEnqueueCmd(config))
+	rootCmd.AddCommand(NewHealthCmd(config))
 	rootCmd.AddCommand(NewInitCmd())
 	rootCmd.AddCommand(NewQueueCmd(config))
 	rootCmd.AddCommand(NewSendCmd(config))

--- a/pkg/client/client.go
+++ b/pkg/client/client.go
@@ -73,6 +73,17 @@ func (c *Client) QueueStatus(routingKey string) (*http.Response, error) {
 	return c.Do(req)
 }
 
+func (c *Client) HealthCheck() (*http.Response, error) {
+	url := generateURL(c.ServerAddress, "/health")
+
+	req, err := http.NewRequest("GET", url.String(), nil)
+
+	if err != nil {
+		return nil, err
+	}
+	return c.Do(req)
+}
+
 func generateURL(serverAddress, path string) *url.URL {
 	return &url.URL{
 		Scheme: "http",

--- a/pkg/eventqueue/errors.go
+++ b/pkg/eventqueue/errors.go
@@ -5,9 +5,9 @@ import (
 	"fmt"
 )
 
-var ErrAPIError = errors.New("An API error was encountered while processing events.")
+var ErrAPIError = errors.New("an API error was encountered while processing events")
 
-var ErrJobStopped = errors.New("Job stopped while retrying.")
+var ErrJobStopped = errors.New("job stopped while retrying")
 
 type ErrBufferOverflow struct {
 	key  string

--- a/pkg/eventqueue/processor.go
+++ b/pkg/eventqueue/processor.go
@@ -2,7 +2,6 @@ package eventqueue
 
 import (
 	"context"
-	"math"
 	"time"
 
 	"github.com/PagerDuty/go-pdagent/pkg/eventsapi"
@@ -23,16 +22,4 @@ func EventProcessor(job Job, stop chan bool) {
 	resp, err := eventsapi.Enqueue(ctx, job.EventContainer)
 
 	job.ResponseChan <- Response{resp, err}
-}
-
-// calculateBackoff returns an exponential duration based on the try count.
-//
-// Currently back-off looks like: 1s, 2s, 4s, 8s, 16s, then capping at
-// MaxRetryTimeout.
-func calculateBackoff(try int) time.Duration {
-	duration := time.Duration(math.Pow(2, float64(try))) * time.Second
-	if duration > MaxRetryTimeout {
-		duration = MaxRetryTimeout
-	}
-	return duration
 }


### PR DESCRIPTION
Adds a simple CLI command to check the health of the agent server.  The primary use of this command at the moment is to check connectivity between the CLI and the server when configuring auth, TLS (in the future), etc.